### PR TITLE
Fix auto installing ps-modules

### DIFF
--- a/prestashop/ps_scripts/install_modules.sh
+++ b/prestashop/ps_scripts/install_modules.sh
@@ -6,8 +6,15 @@ set -e
 INSTALL_COMMAND="${PS_DIR}/bin/console prestashop:module --no-interaction install"
 MODULES_TO_INSTALL=/ps-modules
 
+get_module_name() {
+  local zip_file="$1"
+  local module_name=$(unzip -l "$zip_file" | awk 'NR==4{print $4}' | xargs basename)
+
+  echo "$module_name"
+}
+
 for file in $(ls "${MODULES_TO_INSTALL}"/*.zip); do
-  module=$(basename ${file} .zip | tr "-" "\n" | head -n 1)
+  module=$(get_module_name $file)
   echo "--> installing ${module} from ${file}...";
   rm -rf "${MODULE_DIR}/${module:-something-at-least}"
   unzip -qq ${file} -d ${MODULE_DIR}

--- a/prestashop/ps_scripts/install_modules.sh
+++ b/prestashop/ps_scripts/install_modules.sh
@@ -7,7 +7,7 @@ INSTALL_COMMAND="${PS_DIR}/bin/console prestashop:module --no-interaction instal
 MODULES_TO_INSTALL=/ps-modules
 
 for file in $(ls "${MODULES_TO_INSTALL}"/*.zip); do
-  module=$(basename ${file} | tr "-" "\n" | head -n 1);
+  module=$(basename ${file} .zip | tr "-" "\n" | head -n 1)
   echo "--> installing ${module} from ${file}...";
   rm -rf "${MODULE_DIR}/${module:-something-at-least}"
   unzip -qq ${file} -d ${MODULE_DIR}

--- a/prestashop/ps_scripts/install_modules.sh
+++ b/prestashop/ps_scripts/install_modules.sh
@@ -6,7 +6,7 @@ set -e
 INSTALL_COMMAND="${PS_DIR}/bin/console prestashop:module --no-interaction install"
 MODULES_TO_INSTALL=/ps-modules
 
-for file in $(ls "${MODULES_TO_INSTALL}/*.zip"); do
+for file in $(ls "${MODULES_TO_INSTALL}"/*.zip); do
   module=$(basename ${file} | tr "-" "\n" | head -n 1);
   echo "--> installing ${module} from ${file}...";
   rm -rf "${MODULE_DIR}/${module:-something-at-least}"


### PR DESCRIPTION
The current version has 3 issues when using the "ps-modules" directory to auto-install modules:

1. `ls: cannot access '/ps-modules/*.zip': No such file or directory despite the fact that files are there

2. In the current implementation `basename ${file}` doesn't strip the zip extension properly and the module cannot be installed.

3. If you put a downloaded module zip that doesn't have an archive name like "modulename.zip", it won't work. Usually, they have ps versions, and module versions in the file name. The real name is inside.

After changes from this PR, it started working properly for me.